### PR TITLE
MueLu: Missing output when proc 0 drops out

### DIFF
--- a/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
+++ b/packages/muelu/src/Interface/MueLu_HierarchyManager.hpp
@@ -233,9 +233,7 @@ namespace MueLu {
       // FIXME: Should allow specification of NumVectors on parameterlist
       H.AllocateLevelMultiVectors(1);
       
-      RCP<Teuchos::FancyOStream> fos = this->getOStream();
-      fos->setOutputToRootOnly(0);
-      H.describe(*fos, verbosity_);
+      H.describe(H.GetOStream(Runtime0), verbosity_);
 
       // When we reuse hierarchy, it is necessary that we don't
       // change the number of levels. We also cannot make requests

--- a/packages/muelu/src/MueCentral/MueLu_VerboseObject.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerboseObject.hpp
@@ -113,9 +113,9 @@ namespace MueLu {
 
     Teuchos::FancyOStream & GetBlackHole() const;
 
-    static void SetDefaultOStream(const Teuchos::RCP<Teuchos::FancyOStream> &defaultOStream);
+    static void SetMueLuOStream(const Teuchos::RCP<Teuchos::FancyOStream> &mueluOStream);
 
-    static Teuchos::RCP<Teuchos::FancyOStream> GetDefaultOStream();
+    static Teuchos::RCP<Teuchos::FancyOStream> GetMueLuOStream();
 
     //! @name Public static member functions
     //@{

--- a/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.hpp
+++ b/packages/muelu/src/MueCentral/MueLu_VerbosityLevel.hpp
@@ -78,7 +78,7 @@ namespace MueLu {
       External        = 0x01000000, //!< Print external lib objects
       Debug           = 0x02000000, //!< Print additional debugging information
 
-      Test            = 0x10000000, //!< Print skeleton for the run, i.e. factory calls and used parameters
+      Test0           = 0x10000000, //!< Print skeleton for the run, i.e. factory calls and used parameters
 
       // Predefined combinations of MsgType
       // Can be used in user code or examples. Do not used as input parameters of IsPrint() or GetOStream().
@@ -87,6 +87,7 @@ namespace MueLu {
       Parameters      = Parameters0 | Parameters1,                         //!< Print parameters
       Statistics      = Statistics0 | Statistics1 | Statistics2,           //!< Print all statistics
       Timings         = Timings0 | Timings1 | TimingsByLevel,              //!< Print all timing information
+      Test            = Test0 | Runtime0,
 
       //
       None    = 0,

--- a/packages/muelu/test/interface/complex/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse1_tpetra.gold
@@ -1,254 +1,274 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -258,11 +278,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse2_tpetra.gold
@@ -1,418 +1,450 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -422,13 +454,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse3_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLcoarse5_tpetra.gold
@@ -1,172 +1,186 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -176,10 +190,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLpgamg1_tpetra.gold
@@ -1,344 +1,370 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -348,12 +374,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother1_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother2_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/complex/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother3_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/complex/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLsmoother4_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/MLunsmoothed1_tpetra.gold
@@ -1,308 +1,334 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -312,12 +338,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation1_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/aggregation2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation2_tpetra.gold
@@ -1,153 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::CoupledAggregationFactory)
-   [empty list]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::CoupledAggregationFactory)
+Coarsen Uncoupled (MueLu::LocalAggregationAlgorithm)
+AggregateLeftovers (MueLu::LeftoverAggregationAlgorithm)
+[empty list]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::CoupledAggregationFactory)
-   [empty list]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::CoupledAggregationFactory)
+Coarsen Uncoupled (MueLu::LocalAggregationAlgorithm)
+AggregateLeftovers (MueLu::LeftoverAggregationAlgorithm)
+[empty list]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -157,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation3_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation4_tpetra.gold
@@ -1,199 +1,219 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.05
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = distance laplacian
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0.05,0), blocksize = 1
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.05
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = distance laplacian
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0.05,0), blocksize = 1
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -203,10 +223,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/aggregation5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation5_np4_tpetra.gold
@@ -1,173 +1,185 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +189,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3333   9997     3.00     3.00      4
-  2    1111   3331     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3333  9997   3.00     3.00         4  
+  2  1111  3331   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/aggregation5_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/aggregation5_tpetra.gold
@@ -1,173 +1,185 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +189,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse1_tpetra.gold
@@ -1,269 +1,292 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -273,11 +296,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse2_tpetra.gold
@@ -1,434 +1,471 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -438,13 +475,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/coarse3_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 2.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_e3d_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 3
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 3
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 2.11
 Smoother complexity = 2.22
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333  23319     7.00     3.00      1
-  2    1113   9999     8.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  23319  7.00     3.00         1  
+  2  1113  9999   8.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_mhd_np4_tpetra.gold
@@ -1,143 +1,157 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -147,10 +161,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 1, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [2500, 2500], Global nnz: 7498, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [2500, 2500]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [2500, 2500]}}}}
 

--- a/packages/muelu/test/interface/complex/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_mhd_tpetra.gold
@@ -1,143 +1,157 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -147,10 +161,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}}}
 

--- a/packages/muelu/test/interface/complex/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_p2d_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_p3d_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_pg_np4_tpetra.gold
@@ -1,177 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +195,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/default_pg_tpetra.gold
@@ -1,177 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +195,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar1_np4_tpetra.gold
@@ -1,131 +1,144 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -135,11 +148,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar1_tpetra.gold
@@ -1,392 +1,430 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -396,11 +434,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar2_np4_tpetra.gold
@@ -1,131 +1,144 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -135,11 +148,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/driver_drekar2_tpetra.gold
@@ -1,392 +1,430 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -396,11 +434,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin1_tpetra.gold
@@ -1,189 +1,207 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -193,10 +211,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin2_tpetra.gold
@@ -1,189 +1,207 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -193,10 +211,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/emin3_tpetra.gold
@@ -1,189 +1,207 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -193,10 +211,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/empty_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/onelevel_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/onelevel_tpetra.gold
@@ -1,23 +1,24 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Jacobi   [default]
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Jacobi   [default]
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -27,8 +28,8 @@ Operator complexity = 1.00
 Smoother complexity = 1.33
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/complex/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_1_np1_tpetra.gold
@@ -1,269 +1,292 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -273,11 +296,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/complex/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_1_np4_tpetra.gold
@@ -1,269 +1,292 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -273,11 +296,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np1_tpetra.gold
@@ -1,266 +1,289 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -270,11 +293,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_5_np4_tpetra.gold
@@ -1,266 +1,289 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -270,11 +293,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np1_tpetra.gold
@@ -1,266 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -270,11 +292,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_6_np4_tpetra.gold
@@ -1,266 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -270,11 +292,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np1_tpetra.gold
@@ -1,93 +1,101 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -97,9 +105,9 @@ Operator complexity = 1.30
 Smoother complexity = 1.20
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/operator_solve_7_np4_tpetra.gold
@@ -1,93 +1,101 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -97,9 +105,9 @@ Operator complexity = 1.31
 Smoother complexity = 1.20
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/complex/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/pg1_tpetra.gold
@@ -1,177 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +195,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/pg2_tpetra.gold
@@ -1,177 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +195,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition1_np4_tpetra.gold
@@ -1,258 +1,282 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +286,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition1_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition3_np4_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition3_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition4_np4_tpetra.gold
@@ -1,265 +1,289 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +293,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/repartition4_tpetra.gold
@@ -1,265 +1,289 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +293,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-1_np4_tpetra.gold
@@ -1,258 +1,280 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +284,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,26 +296,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -305,10 +328,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-1_tpetra.gold
@@ -1,265 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +292,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,26 +304,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -312,10 +336,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-2_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -250,26 +272,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -281,10 +304,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RAP-2_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -257,26 +280,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -288,10 +312,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RP-2_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -250,107 +272,117 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -360,10 +392,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-RP-2_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -257,114 +280,124 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -374,10 +407,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-S-1_np4_tpetra.gold
@@ -1,258 +1,280 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +284,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,261 +296,283 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -538,10 +582,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-S-1_tpetra.gold
@@ -1,265 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +292,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,268 +304,290 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -552,10 +597,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-full-1_np4_tpetra.gold
@@ -1,258 +1,280 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +284,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,6 +296,7 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -286,10 +309,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-full-1_tpetra.gold
@@ -1,265 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +292,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,6 +304,7 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -293,10 +317,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-none_np4_tpetra.gold
@@ -1,258 +1,282 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +286,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,261 +298,285 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -538,10 +586,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-none_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,268 +306,292 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -552,10 +601,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-1_np4_tpetra.gold
@@ -1,258 +1,282 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +286,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,175 +298,191 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -452,10 +492,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-1_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,182 +306,198 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -466,10 +507,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-2_np4_tpetra.gold
@@ -1,258 +1,282 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +286,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,215 +298,235 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0.02
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -492,10 +536,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-2_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,222 +306,242 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0.02
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0.02,0), blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -506,10 +551,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -250,184 +272,201 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -437,10 +476,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/reuse-tP-3_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -257,191 +280,208 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -451,10 +491,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother10_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother11_tpetra.gold
@@ -1,221 +1,237 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -225,10 +241,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 0, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/complex/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother12_tpetra.gold
@@ -1,441 +1,478 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -445,13 +482,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother13_tpetra.gold
@@ -1,197 +1,213 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -201,10 +217,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}

--- a/packages/muelu/test/interface/complex/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother1_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother2_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/complex/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother3_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/complex/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother4_tpetra.gold
@@ -1,145 +1,161 @@
+Clearing old data (if any)
 Level 0
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -149,10 +165,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/complex/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother5_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother6_tpetra.gold
@@ -1,159 +1,175 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +179,10 @@ Operator complexity = 1.44
 Smoother complexity = 2.67
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/smoother9_tpetra.gold
@@ -1,197 +1,213 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -201,10 +217,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/complex/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/sync1_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose1_tpetra.gold
@@ -1,175 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -179,10 +195,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose2_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose2_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose3_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/transpose3_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/complex/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/complex/Output/unsmoothed1_tpetra.gold
@@ -1,159 +1,173 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = (0,0), blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +177,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_epetra.gold
@@ -1,119 +1,128 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0.01
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = distance laplacian
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.01, blocksize = 1
+aggregation: drop tol = 0.01
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -123,9 +132,9 @@ Operator complexity = 1.33
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLaux_tpetra.gold
@@ -1,129 +1,138 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0.01
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = distance laplacian
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.01, blocksize = 1
+aggregation: drop tol = 0.01
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -133,9 +142,9 @@ Operator complexity = 1.33
 Smoother complexity = 1.33
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1_epetra.gold
@@ -1,224 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -228,11 +248,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1_tpetra.gold
@@ -1,254 +1,274 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -258,11 +278,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse1b_epetra.gold
@@ -1,239 +1,262 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -243,11 +266,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2_epetra.gold
@@ -1,368 +1,400 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -372,13 +404,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2_tpetra.gold
@@ -1,418 +1,450 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -422,13 +454,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse2b_epetra.gold
@@ -1,391 +1,428 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -395,13 +432,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3_epetra.gold
@@ -1,296 +1,322 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -300,12 +326,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse3b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse3b_epetra.gold
@@ -1,315 +1,345 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -319,12 +349,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse4_epetra.gold
@@ -1,299 +1,325 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
-  relaxation: sweeps = 25   [unused]
-  relaxation: damping factor = 0.6   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+ relaxation: sweeps = 25   [unused]
+ relaxation: damping factor = 0.6   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -303,12 +329,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse4_tpetra.gold
@@ -1,349 +1,375 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 25
-  relaxation: damping factor = 0.6
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 25
+ relaxation: damping factor = 0.6
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -353,12 +379,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse4b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse4b_epetra.gold
@@ -1,317 +1,347 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
-  relaxation: sweeps = 25   [unused]
-  relaxation: damping factor = 0.6   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+ relaxation: sweeps = 25   [unused]
+ relaxation: damping factor = 0.6   [unused]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -321,12 +351,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse5_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse5_epetra.gold
@@ -1,152 +1,166 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -156,10 +170,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLcoarse5_tpetra.gold
@@ -1,172 +1,186 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -176,10 +190,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLempty_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLempty_epetra.gold
@@ -1,296 +1,322 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -300,12 +326,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLemptyb_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLemptyb_epetra.gold
@@ -1,315 +1,345 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -319,12 +349,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLpgamg1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1_epetra.gold
@@ -1,304 +1,330 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -308,12 +334,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1_tpetra.gold
@@ -1,344 +1,370 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -348,12 +374,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLpgamg1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg1b_epetra.gold
@@ -1,303 +1,329 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -307,12 +333,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLpgamg2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg2_epetra.gold
@@ -1,296 +1,322 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -300,12 +326,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLpgamg2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLpgamg2b_epetra.gold
@@ -1,339 +1,369 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-  sa: damping factor = 1.333
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-  sa: damping factor = 1.333
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-  sa: damping factor = 1.333
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-  sa: damping factor = 1.333
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -343,12 +373,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_epetra.gold
@@ -1,551 +1,597 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 5
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -555,13 +601,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning1_tpetra.gold
@@ -1,601 +1,647 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -605,13 +651,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_epetra.gold
@@ -1,443 +1,479 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -447,12 +483,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning2_tpetra.gold
@@ -1,483 +1,519 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -487,12 +523,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_epetra.gold
@@ -1,443 +1,479 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -447,12 +483,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLrepartitioning3_tpetra.gold
@@ -1,483 +1,519 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-       Build (MueLu::CoalesceDropFactory)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -487,12 +523,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLsmoother1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1_epetra.gold
@@ -1,296 +1,322 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -300,12 +326,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLsmoother1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother1b_epetra.gold
@@ -1,315 +1,345 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -319,12 +349,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLsmoother2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2_epetra.gold
@@ -1,296 +1,322 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -300,12 +326,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/MLsmoother2b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother2b_epetra.gold
@@ -1,315 +1,345 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -319,12 +349,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/MLsmoother3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3_epetra.gold
@@ -1,296 +1,322 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -300,12 +326,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : MueLu::IfpackSmoother{type = point relaxation stand-alone}

--- a/packages/muelu/test/interface/default/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/default/Output/MLsmoother3b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother3b_epetra.gold
@@ -1,315 +1,345 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -319,12 +349,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : MueLu::IfpackSmoother{type = point relaxation stand-alone}

--- a/packages/muelu/test/interface/default/Output/MLsmoother4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4_epetra.gold
@@ -1,292 +1,318 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -296,12 +322,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4_tpetra.gold
@@ -1,312 +1,338 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -316,12 +342,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLsmoother4b_epetra.gold
@@ -1,311 +1,341 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -315,12 +345,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1_epetra.gold
@@ -1,268 +1,294 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -272,12 +298,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1_tpetra.gold
@@ -1,308 +1,334 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -312,12 +338,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/MLunsmoothed1b_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/MLunsmoothed1b_epetra.gold
@@ -1,315 +1,345 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 0
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 0
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 0
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 0
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 0
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 0
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 0
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 0
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -319,12 +349,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/aggregation1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation1_epetra.gold
@@ -1,163 +1,179 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -167,10 +183,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation1_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/aggregation2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation2_epetra.gold
@@ -1,133 +1,143 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::CoupledAggregationFactory)
-   [empty list]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::CoupledAggregationFactory)
+Coarsen Uncoupled (MueLu::LocalAggregationAlgorithm)
+AggregateLeftovers (MueLu::LeftoverAggregationAlgorithm)
+[empty list]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::CoupledAggregationFactory)
-   [empty list]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::CoupledAggregationFactory)
+Coarsen Uncoupled (MueLu::LocalAggregationAlgorithm)
+AggregateLeftovers (MueLu::LeftoverAggregationAlgorithm)
+[empty list]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -137,10 +147,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/aggregation2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation2_tpetra.gold
@@ -1,153 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::CoupledAggregationFactory)
-   [empty list]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::CoupledAggregationFactory)
+Coarsen Uncoupled (MueLu::LocalAggregationAlgorithm)
+AggregateLeftovers (MueLu::LeftoverAggregationAlgorithm)
+[empty list]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::CoupledAggregationFactory)
-   [empty list]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::CoupledAggregationFactory)
+Coarsen Uncoupled (MueLu::LocalAggregationAlgorithm)
+AggregateLeftovers (MueLu::LeftoverAggregationAlgorithm)
+[empty list]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -157,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/aggregation3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation3_epetra.gold
@@ -1,163 +1,179 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -167,10 +183,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation3_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/aggregation4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation4_epetra.gold
@@ -1,179 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.05
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = distance laplacian
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.05
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = distance laplacian
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -183,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation4_tpetra.gold
@@ -1,199 +1,219 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.05
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = distance laplacian
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.05
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = distance laplacian
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -203,10 +223,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/aggregation5_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_epetra.gold
@@ -1,153 +1,165 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -157,10 +169,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/aggregation5_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_np4_epetra.gold
@@ -1,153 +1,165 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -157,10 +169,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3333   9997     3.00     3.00      4
-  2    1111   3331     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3333  9997   3.00     3.00         4  
+  2  1111  3331   3.00     3.00         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/aggregation5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_np4_tpetra.gold
@@ -1,173 +1,185 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +189,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3333   9997     3.00     3.00      4
-  2    1111   3331     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3333  9997   3.00     3.00         4  
+  2  1111  3331   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/aggregation5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/aggregation5_tpetra.gold
@@ -1,173 +1,185 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::BrickAggregationFactory)
-   aggregation: brick x size = 3
-   aggregation: brick y size = 2   [default]
-   aggregation: brick z size = 2   [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory)
- structured aggregation = 0   [default]
- aggregation coupled = 0   [default]
- Geometric = 0   [default]
- write start = -1   [default]
- write end = -1   [default]
- hybrid aggregation = 0   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::BrickAggregationFactory)
+Using brick size: 3
+aggregation: brick x size = 3
+aggregation: brick y size = 2   [default]
+aggregation: brick z size = 2   [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +189,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/coarse1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse1_epetra.gold
@@ -1,239 +1,262 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -243,11 +266,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse1_tpetra.gold
@@ -1,269 +1,292 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -273,11 +296,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/coarse2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse2_epetra.gold
@@ -1,384 +1,421 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -388,13 +425,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse2_tpetra.gold
@@ -1,434 +1,471 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -438,13 +475,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/coarse3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse3_epetra.gold
@@ -1,163 +1,179 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -167,10 +183,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/coarse3_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 2.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_e3d_tpetra.gold
@@ -1,171 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 3
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 3
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -175,10 +191,10 @@ Operator complexity = 2.11
 Smoother complexity = 2.22
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333  23319     7.00     3.00      1
-  2    1113   9999     8.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  23319  7.00     3.00         1  
+  2  1113  9999   8.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_mhd_np4_tpetra.gold
@@ -1,143 +1,157 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -147,10 +161,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 1, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [2500, 2500], Global nnz: 7498, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [2500, 2500]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [2500, 2500]}}}}
 

--- a/packages/muelu/test/interface/default/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_mhd_tpetra.gold
@@ -1,143 +1,157 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -147,10 +161,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}}}
 

--- a/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p2d_tpetra.gold
@@ -1,171 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -175,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_p3d_tpetra.gold
@@ -1,171 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -175,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/default_pg_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_epetra.gold
@@ -1,153 +1,167 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -157,10 +171,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/default_pg_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_np4_epetra.gold
@@ -1,153 +1,167 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -157,10 +171,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_np4_tpetra.gold
@@ -1,177 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +195,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/default_pg_tpetra.gold
@@ -1,177 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +195,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_epetra.gold
@@ -1,368 +1,406 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -372,11 +410,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_epetra.gold
@@ -1,123 +1,136 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -127,11 +140,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_np4_tpetra.gold
@@ -1,126 +1,139 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -130,11 +143,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar1_tpetra.gold
@@ -1,377 +1,415 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -381,11 +419,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_epetra.gold
@@ -1,368 +1,406 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -372,11 +410,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_epetra.gold
@@ -1,123 +1,136 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -127,11 +140,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_np4_tpetra.gold
@@ -1,126 +1,139 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -130,11 +143,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/driver_drekar2_tpetra.gold
@@ -1,377 +1,415 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = distance laplacian
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -381,11 +419,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/emin1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin1_epetra.gold
@@ -1,169 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin1_tpetra.gold
@@ -1,189 +1,207 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -193,10 +211,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/emin2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin2_epetra.gold
@@ -1,169 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin2_tpetra.gold
@@ -1,189 +1,207 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -193,10 +211,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/emin3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin3_epetra.gold
@@ -1,169 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/emin3_tpetra.gold
@@ -1,189 +1,207 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -193,10 +211,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/empty_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/empty_epetra.gold
@@ -1,163 +1,179 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -167,10 +183,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/empty_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/onelevel_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/onelevel_epetra.gold
@@ -1,11 +1,12 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -15,8 +16,8 @@ Operator complexity = 1.00
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/onelevel_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/onelevel_tpetra.gold
@@ -1,23 +1,24 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Jacobi   [default]
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Jacobi   [default]
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -27,8 +28,8 @@ Operator complexity = 1.00
 Smoother complexity = 1.33
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np1_epetra.gold
@@ -1,239 +1,262 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -243,11 +266,11 @@ Operator complexity = 1.34
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np1_tpetra.gold
@@ -1,269 +1,292 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -273,11 +296,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np4_epetra.gold
@@ -1,239 +1,262 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = Klu})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -243,11 +266,11 @@ Operator complexity = 1.36
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -255,6 +278,6 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 
 Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
+Smoother (level 3) pre  : MueLu::AmesosSmoother{type = Klu}
 Smoother (level 3) post : no smoother
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_1_np4_tpetra.gold
@@ -1,269 +1,292 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -273,11 +296,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np1_epetra.gold
@@ -1,236 +1,259 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,11 +263,11 @@ Operator complexity = 1.34
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np1_tpetra.gold
@@ -1,266 +1,289 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -270,11 +293,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np4_epetra.gold
@@ -1,236 +1,259 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = Klu})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,11 +263,11 @@ Operator complexity = 1.36
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -252,6 +275,6 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 
 Smoother (level 2) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
-Smoother (level 3) pre  : MueLu::AmesosSmoother{type = <ignored>}
+Smoother (level 3) pre  : MueLu::AmesosSmoother{type = Klu}
 Smoother (level 3) post : no smoother
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_5_np4_tpetra.gold
@@ -1,266 +1,289 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -270,11 +293,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np1_epetra.gold
@@ -1,236 +1,258 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,11 +262,11 @@ Operator complexity = 1.34
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np1_tpetra.gold
@@ -1,266 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -270,11 +292,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np4_epetra.gold
@@ -1,236 +1,258 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,11 +262,11 @@ Operator complexity = 1.36
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_6_np4_tpetra.gold
@@ -1,266 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -270,11 +292,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np1_epetra.gold
@@ -1,83 +1,91 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -87,9 +95,9 @@ Operator complexity = 1.30
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np1_tpetra.gold
@@ -1,93 +1,101 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -97,9 +105,9 @@ Operator complexity = 1.30
 Smoother complexity = 1.20
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np4_epetra.gold
@@ -1,83 +1,91 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -87,9 +95,9 @@ Operator complexity = 1.31
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/operator_solve_7_np4_tpetra.gold
@@ -1,93 +1,101 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -97,9 +105,9 @@ Operator complexity = 1.31
 Smoother complexity = 1.20
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/default/Output/pg1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg1_epetra.gold
@@ -1,157 +1,171 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -161,10 +175,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg1_tpetra.gold
@@ -1,177 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +195,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/pg2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg2_epetra.gold
@@ -1,157 +1,171 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -161,10 +175,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/pg2_tpetra.gold
@@ -1,177 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +195,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_epetra.gold
@@ -1,245 +1,270 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +274,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_epetra.gold
@@ -1,238 +1,262 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -242,10 +266,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_np4_tpetra.gold
@@ -1,258 +1,282 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +286,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition1_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_epetra.gold
@@ -1,245 +1,270 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +274,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_epetra.gold
@@ -1,245 +1,270 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +274,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_np4_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition3_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_epetra.gold
@@ -1,245 +1,269 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +273,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_epetra.gold
@@ -1,245 +1,269 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  Reindex = 1
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ Reindex = 1
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +273,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_np4_tpetra.gold
@@ -1,265 +1,289 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +293,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/repartition4_tpetra.gold
@@ -1,265 +1,289 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +293,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_epetra.gold
@@ -1,245 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +272,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -261,16 +284,17 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
 Level 2
 
@@ -282,10 +306,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_epetra.gold
@@ -1,238 +1,260 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -242,10 +264,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -254,16 +276,17 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
 Level 2
 
@@ -275,10 +298,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_np4_tpetra.gold
@@ -1,258 +1,280 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +284,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,26 +296,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -305,10 +328,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-1_tpetra.gold
@@ -1,265 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +292,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,26 +304,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -312,10 +336,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_epetra.gold
@@ -1,221 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -225,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -237,16 +260,17 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
 Level 2
 
@@ -258,10 +282,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_epetra.gold
@@ -1,214 +1,236 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -218,10 +240,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -230,16 +252,17 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
 Level 2
 
@@ -251,10 +274,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -250,26 +272,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -281,10 +304,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RAP-2_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -257,26 +280,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -288,10 +312,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_epetra.gold
@@ -1,221 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -225,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -237,94 +260,104 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -334,10 +367,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_epetra.gold
@@ -1,214 +1,236 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -218,10 +240,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -230,87 +252,97 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -320,10 +352,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -250,107 +272,117 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -360,10 +392,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-RP-2_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -257,114 +280,124 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -374,10 +407,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_epetra.gold
@@ -1,245 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +272,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -261,248 +284,270 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -512,10 +557,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_epetra.gold
@@ -1,238 +1,260 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -242,10 +264,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -254,241 +276,263 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -498,10 +542,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_np4_tpetra.gold
@@ -1,258 +1,280 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +284,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,261 +296,283 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -538,10 +582,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-S-1_tpetra.gold
@@ -1,265 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +292,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,268 +304,290 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -552,10 +597,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_epetra.gold
@@ -1,245 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +272,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -261,6 +284,7 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -273,10 +297,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_epetra.gold
@@ -1,238 +1,260 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -242,10 +264,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -254,6 +276,7 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -266,10 +289,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_np4_tpetra.gold
@@ -1,258 +1,280 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +284,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,6 +296,7 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -286,10 +309,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-full-1_tpetra.gold
@@ -1,265 +1,288 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +292,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,6 +304,7 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -293,10 +317,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_epetra.gold
@@ -1,245 +1,270 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +274,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -261,248 +286,272 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -512,10 +561,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_epetra.gold
@@ -1,238 +1,262 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -242,10 +266,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -254,241 +278,265 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -498,10 +546,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_np4_tpetra.gold
@@ -1,258 +1,282 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +286,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,261 +298,285 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -538,10 +586,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-none_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,268 +306,292 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -552,10 +601,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_epetra.gold
@@ -1,245 +1,270 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +274,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -261,162 +286,178 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -426,10 +467,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_epetra.gold
@@ -1,238 +1,262 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -242,10 +266,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -254,155 +278,171 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -412,10 +452,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_np4_tpetra.gold
@@ -1,258 +1,282 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +286,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,175 +298,191 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -452,10 +492,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-1_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,182 +306,198 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-   Reusing previous AP data
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Reusing previous AP data
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -466,10 +507,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_epetra.gold
@@ -1,245 +1,270 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,10 +274,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -261,202 +286,222 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0.02
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -466,10 +511,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_epetra.gold
@@ -1,238 +1,262 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -242,10 +266,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -254,195 +278,215 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0.02
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -452,10 +496,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_np4_tpetra.gold
@@ -1,258 +1,282 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -262,10 +286,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -274,215 +298,235 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0.02
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -492,10 +536,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-2_tpetra.gold
@@ -1,265 +1,290 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -269,10 +294,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -281,222 +306,242 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory)
-   Matrix filtering (MueLu::FilteredAFactory)
-    Build (MueLu::CoalesceDropFactory)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0.02
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    lightweight wrap = 1
-    
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0.02
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Lumping dropped entries
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -506,10 +551,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_epetra.gold
@@ -1,221 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -225,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -237,171 +260,188 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -411,10 +451,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_epetra.gold
@@ -1,214 +1,236 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -218,10 +240,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -230,164 +252,181 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -397,10 +436,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -250,184 +272,201 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -437,10 +476,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/reuse-tP-3_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -257,191 +280,208 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory)
-  structured aggregation = 0   [default]
-  aggregation coupled = 0   [default]
-  Geometric = 0   [default]
-  write start = -1   [default]
-  write end = -1   [default]
-  hybrid aggregation = 0   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+Reusing coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory)
-     Build (MueLu::UncoupledAggregationFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     aggregation: use interface aggregation = 0   [default]
-     aggregation: error on nodes with no on-rank neighbors = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     Interface aggregate map name =    [default]
-     Interface aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory)
-     Striding info = {}   [default]
-     Strided block id = -1   [default]
-     Domain GID offsets = {0}   [default]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -451,10 +491,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/smoother10_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother10_epetra.gold
@@ -1,159 +1,175 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +179,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother10_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/smoother11_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother11_epetra.gold
@@ -1,173 +1,189 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +193,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : MueLu::IfpackSmoother{type = point relaxation stand-alone}

--- a/packages/muelu/test/interface/default/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother11_tpetra.gold
@@ -1,221 +1,237 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -225,10 +241,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 0, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/default/Output/smoother12_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother12_epetra.gold
@@ -1,381 +1,418 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 5   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 5   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 4   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 4   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2.99461   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2.99461   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2.99194   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2.99194   [unused]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -385,13 +422,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother12_tpetra.gold
@@ -1,411 +1,448 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 5
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 5
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 4
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 4
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2.99461
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2.99461
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2.99194
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2.99194
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -415,13 +452,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/smoother13_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother13_epetra.gold
@@ -1,173 +1,189 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILU})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILU})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILU})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILU})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +193,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = Chebyshev}
 Smoother (level 0) post : MueLu::IfpackSmoother{type = ILU}

--- a/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother13_tpetra.gold
@@ -1,185 +1,201 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -189,10 +205,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}

--- a/packages/muelu/test/interface/default/Output/smoother1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother1_epetra.gold
@@ -1,163 +1,179 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -167,10 +183,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother1_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/smoother2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother2_epetra.gold
@@ -1,163 +1,179 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -167,10 +183,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother2_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/smoother3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother3_epetra.gold
@@ -1,163 +1,179 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -167,10 +183,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : MueLu::IfpackSmoother{type = point relaxation stand-alone}

--- a/packages/muelu/test/interface/default/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother3_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/default/Output/smoother4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother4_epetra.gold
@@ -1,145 +1,161 @@
+Clearing old data (if any)
 Level 0
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -149,10 +165,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother4_tpetra.gold
@@ -1,145 +1,161 @@
+Clearing old data (if any)
 Level 0
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -149,10 +165,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/default/Output/smoother5_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother5_epetra.gold
@@ -1,159 +1,175 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +179,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother5_tpetra.gold
@@ -1,171 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -175,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/smoother6_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother6_epetra.gold
@@ -1,159 +1,175 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +179,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = ILUT}
 

--- a/packages/muelu/test/interface/default/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother6_tpetra.gold
@@ -1,159 +1,175 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +179,10 @@ Operator complexity = 1.44
 Smoother complexity = 2.67
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/smoother9_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother9_epetra.gold
@@ -1,173 +1,189 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +193,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = Chebyshev}
 Smoother (level 0) post : MueLu::IfpackSmoother{type = ILUT}

--- a/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/smoother9_tpetra.gold
@@ -1,185 +1,201 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -189,10 +205,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/default/Output/sync1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/sync1_epetra.gold
@@ -1,163 +1,179 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -167,10 +183,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/sync1_tpetra.gold
@@ -1,183 +1,199 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +203,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/transpose1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose1_epetra.gold
@@ -1,155 +1,171 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -159,10 +175,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose1_tpetra.gold
@@ -1,175 +1,191 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory)
-  Matrix filtering (MueLu::FilteredAFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  
-  Build (MueLu::TentativePFactory)
-   Build (MueLu::UncoupledAggregationFactory)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   aggregation: use interface aggregation = 0   [default]
-   aggregation: error on nodes with no on-rank neighbors = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   Interface aggregate map name =    [default]
-   Interface aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory)
-   Striding info = {}   [default]
-   Strided block id = -1   [default]
-   Domain GID offsets = {0}   [default]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -179,10 +195,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_epetra.gold
@@ -1,221 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -225,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_epetra.gold
@@ -1,214 +1,236 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -218,10 +240,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose2_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_epetra.gold
@@ -1,221 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -225,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_epetra.gold
@@ -1,214 +1,236 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -218,10 +240,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_np4_tpetra.gold
@@ -1,234 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -238,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/transpose3_tpetra.gold
@@ -1,241 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory)
-     Matrix filtering (MueLu::FilteredAFactory)
-      Build (MueLu::CoalesceDropFactory)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      lightweight wrap = 1
-      
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     
-     Build (MueLu::TentativePFactory)
-      Build (MueLu::UncoupledAggregationFactory)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      aggregation: use interface aggregation = 0   [default]
-      aggregation: error on nodes with no on-rank neighbors = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      Interface aggregate map name =    [default]
-      Interface aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory)
-      Striding info = {}   [default]
-      Strided block id = -1   [default]
-      Domain GID offsets = {0}   [default]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory)
-   structured aggregation = 0   [default]
-   aggregation coupled = 0   [default]
-   Geometric = 0   [default]
-   write start = -1   [default]
-   write end = -1   [default]
-   hybrid aggregation = 0   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory)
+Matrix filtering (MueLu::FilteredAFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+Filtered matrix is not being constructed as no filtering is being done
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory
+Build (MueLu::CoordinatesTransferFactory)
+Transferring coordinates
+structured aggregation = 0   [default]
+aggregation coupled = 0   [default]
+Geometric = 0   [default]
+write start = -1   [default]
+write end = -1   [default]
+hybrid aggregation = 0   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -245,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/default/Output/unsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/default/Output/unsmoothed1_epetra.gold
@@ -1,139 +1,153 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -143,10 +157,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/default/Output/unsmoothed1_tpetra.gold
@@ -1,159 +1,173 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory)
-  Build (MueLu::UncoupledAggregationFactory)
-   Build (MueLu::CoalesceDropFactory)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  aggregation: use interface aggregation = 0   [default]
-  aggregation: error on nodes with no on-rank neighbors = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  Interface aggregate map name =    [default]
-  Interface aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory)
-  Striding info = {}   [default]
-  Strided block id = -1   [default]
-  Domain GID offsets = {0}   [default]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory)
+Build (MueLu::UncoupledAggregationFactory)
+Build (MueLu::CoalesceDropFactory)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+aggregation: use interface aggregation = 0   [default]
+aggregation: error on nodes with no on-rank neighbors = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+Interface aggregate map name =    [default]
+Interface aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory)
+Striding info = {}   [default]
+Strided block id = -1   [default]
+Domain GID offsets = {0}   [default]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +177,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse1_tpetra.gold
@@ -1,248 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -252,11 +272,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse2_tpetra.gold
@@ -1,408 +1,440 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -412,13 +444,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse3_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLcoarse5_tpetra.gold
@@ -1,168 +1,182 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -172,10 +186,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLpgamg1_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother1_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother2_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother3_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLsmoother4_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/MLunsmoothed1_tpetra.gold
@@ -1,300 +1,326 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -304,12 +330,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation1_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation3_tpetra.gold
@@ -1,169 +1,185 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.02
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.02
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +189,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/aggregation4_tpetra.gold
@@ -1,177 +1,197 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.05
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = distance laplacian
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory_kokkos)
- write start = -1   [default]
- write end = -1   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.05
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = distance laplacian
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory_kokkos)
- write start = -1   [default]
- write end = -1   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +201,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse1_tpetra.gold
@@ -1,248 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -252,11 +272,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse2_tpetra.gold
@@ -1,399 +1,431 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -403,13 +435,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/coarse3_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 2.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_e3d_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 3
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 3
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 2.11
 Smoother complexity = 2.22
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333  23319     7.00     3.00      1
-  2    1113   9999     8.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  23319  7.00     3.00         1  
+  2  1113  9999   8.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_np4_tpetra.gold
@@ -1,139 +1,153 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -143,10 +157,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 1, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [2500, 2500], Global nnz: 7498, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [2500, 2500]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [2500, 2500]}}}}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_mhd_tpetra.gold
@@ -1,139 +1,153 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -143,10 +157,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}}}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_p2d_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_p3d_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_pg_np4_tpetra.gold
@@ -1,173 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +191,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/default_pg_tpetra.gold
@@ -1,173 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_np4_tpetra.gold
@@ -1,120 +1,132 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -124,11 +136,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar1_tpetra.gold
@@ -1,359 +1,394 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -363,11 +398,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_np4_tpetra.gold
@@ -1,120 +1,133 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -124,11 +137,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/driver_drekar2_tpetra.gold
@@ -1,359 +1,397 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -363,11 +401,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin1_tpetra.gold
@@ -1,185 +1,203 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -189,10 +207,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin2_tpetra.gold
@@ -1,185 +1,203 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -189,10 +207,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/emin3_tpetra.gold
@@ -1,185 +1,203 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -189,10 +207,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/empty_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/onelevel_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/onelevel_tpetra.gold
@@ -1,23 +1,24 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Jacobi   [default]
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Jacobi   [default]
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -27,8 +28,8 @@ Operator complexity = 1.00
 Smoother complexity = 1.33
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np1_tpetra.gold
@@ -1,248 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -252,11 +272,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_1_np4_tpetra.gold
@@ -1,248 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -252,11 +272,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np1_tpetra.gold
@@ -1,245 +1,265 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,11 +269,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_5_np4_tpetra.gold
@@ -1,245 +1,265 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,11 +269,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np1_tpetra.gold
@@ -1,245 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,11 +268,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_6_np4_tpetra.gold
@@ -1,245 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,11 +268,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np1_tpetra.gold
@@ -1,86 +1,93 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -90,9 +97,9 @@ Operator complexity = 1.30
 Smoother complexity = 1.20
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/operator_solve_7_np4_tpetra.gold
@@ -1,86 +1,93 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -90,9 +97,9 @@ Operator complexity = 1.31
 Smoother complexity = 1.20
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/pg1_tpetra.gold
@@ -1,173 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/pg2_tpetra.gold
@@ -1,173 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_np4_tpetra.gold
@@ -1,236 +1,258 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +262,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition1_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_np4_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition3_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_np4_tpetra.gold
@@ -1,243 +1,265 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +269,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/repartition4_tpetra.gold
@@ -1,243 +1,265 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +269,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_np4_tpetra.gold
@@ -1,236 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,26 +272,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -283,10 +304,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-1_tpetra.gold
@@ -1,243 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,26 +280,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -290,10 +312,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_np4_tpetra.gold
@@ -1,212 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -216,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -228,26 +248,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -259,10 +280,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RAP-2_tpetra.gold
@@ -1,219 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,10 +244,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -235,26 +256,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -266,10 +288,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_np4_tpetra.gold
@@ -1,212 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -216,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -228,99 +248,109 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -330,10 +360,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-RP-2_tpetra.gold
@@ -1,219 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,10 +244,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -235,106 +256,116 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -344,10 +375,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_np4_tpetra.gold
@@ -1,236 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,239 +272,259 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -494,10 +534,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-S-1_tpetra.gold
@@ -1,243 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,246 +280,266 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -508,10 +549,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_np4_tpetra.gold
@@ -1,236 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,6 +272,7 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -264,10 +285,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-full-1_tpetra.gold
@@ -1,243 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,6 +280,7 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -271,10 +293,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_np4_tpetra.gold
@@ -1,236 +1,258 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +262,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,239 +274,261 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -494,10 +538,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-none_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,246 +282,268 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -508,10 +553,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_np4_tpetra.gold
@@ -1,236 +1,258 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +262,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,161 +274,175 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -416,10 +452,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-1_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,168 +282,182 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -430,10 +467,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_np4_tpetra.gold
@@ -1,236 +1,260 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +264,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,198 +276,218 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -453,10 +497,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-2_tpetra.gold
@@ -1,243 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +272,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,205 +284,225 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -467,10 +512,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_np4_tpetra.gold
@@ -1,222 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -226,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -238,174 +260,191 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -415,10 +454,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/reuse-tP-3_tpetra.gold
@@ -1,229 +1,252 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -233,10 +256,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -245,181 +268,198 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -429,10 +469,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother10_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother11_tpetra.gold
@@ -1,207 +1,221 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -211,10 +225,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 0, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother12_tpetra.gold
@@ -1,406 +1,438 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -410,13 +442,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother13_tpetra.gold
@@ -1,183 +1,197 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +201,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother1_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother2_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother3_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother4_tpetra.gold
@@ -1,131 +1,145 @@
+Clearing old data (if any)
 Level 0
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -135,10 +149,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother5_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother6_tpetra.gold
@@ -1,145 +1,159 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -149,10 +163,10 @@ Operator complexity = 1.44
 Smoother complexity = 2.67
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/smoother9_tpetra.gold
@@ -1,183 +1,197 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -187,10 +201,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos-complex/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/sync1_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose1_tpetra.gold
@@ -1,161 +1,175 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -165,10 +179,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_np4_tpetra.gold
@@ -1,212 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -216,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose2_tpetra.gold
@@ -1,219 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,10 +244,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_np4_tpetra.gold
@@ -1,212 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -216,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/transpose3_tpetra.gold
@@ -1,219 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,10 +244,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos-complex/Output/unsmoothed1_tpetra.gold
@@ -1,155 +1,169 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -159,10 +173,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_epetra.gold
@@ -1,117 +1,127 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0.01
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = distance laplacian
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.01, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.01
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -121,9 +131,9 @@ Operator complexity = 1.33
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLaux_tpetra.gold
@@ -1,127 +1,137 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0.01
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = distance laplacian
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.01, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.01
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -131,9 +141,9 @@ Operator complexity = 1.33
 Smoother complexity = 1.33
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1_epetra.gold
@@ -1,218 +1,238 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -222,11 +242,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1_tpetra.gold
@@ -1,248 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -252,11 +272,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse1b_epetra.gold
@@ -1,218 +1,238 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -222,11 +242,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2_epetra.gold
@@ -1,358 +1,390 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -362,13 +394,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2_tpetra.gold
@@ -1,408 +1,440 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -412,13 +444,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse2b_epetra.gold
@@ -1,356 +1,388 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -360,13 +392,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3_epetra.gold
@@ -1,288 +1,314 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -292,12 +318,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse3b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse3b_epetra.gold
@@ -1,287 +1,313 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -291,12 +317,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4_epetra.gold
@@ -1,291 +1,317 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
-  relaxation: sweeps = 25   [unused]
-  relaxation: damping factor = 0.6   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+ relaxation: sweeps = 25   [unused]
+ relaxation: damping factor = 0.6   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -295,12 +321,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4_tpetra.gold
@@ -1,341 +1,367 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 25
-  relaxation: damping factor = 0.6
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 25
+ relaxation: damping factor = 0.6
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -345,12 +371,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse4b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse4b_epetra.gold
@@ -1,289 +1,315 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
-  relaxation: sweeps = 25   [unused]
-  relaxation: damping factor = 0.6   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+ relaxation: sweeps = 25   [unused]
+ relaxation: damping factor = 0.6   [unused]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -293,12 +319,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse5_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse5_epetra.gold
@@ -1,148 +1,162 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -152,10 +166,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLcoarse5_tpetra.gold
@@ -1,168 +1,182 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -172,10 +186,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLempty_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLempty_epetra.gold
@@ -1,288 +1,314 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -292,12 +318,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLemptyb_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLemptyb_epetra.gold
@@ -1,287 +1,313 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -291,12 +317,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1_epetra.gold
@@ -1,296 +1,322 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -300,12 +326,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1_tpetra.gold
@@ -1,336 +1,362 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -340,12 +366,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg1b_epetra.gold
@@ -1,295 +1,321 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -299,12 +325,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg2_epetra.gold
@@ -1,288 +1,314 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -292,12 +318,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLpgamg2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLpgamg2b_epetra.gold
@@ -1,311 +1,337 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  sa: damping factor = 1.333
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  sa: damping factor = 1.333
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  sa: damping factor = 1.333
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  sa: damping factor = 1.333
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -315,12 +341,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_epetra.gold
@@ -1,541 +1,587 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 5
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -545,13 +591,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning1_tpetra.gold
@@ -1,591 +1,637 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 512
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.3
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 512
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.3
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -595,13 +641,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_epetra.gold
@@ -1,435 +1,471 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -439,12 +475,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning2_tpetra.gold
@@ -1,475 +1,511 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 1000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 1000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -479,12 +515,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_epetra.gold
@@ -1,435 +1,471 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -439,12 +475,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLrepartitioning3_tpetra.gold
@@ -1,475 +1,511 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-       Build (MueLu::CoalesceDropFactory_kokkos)
-        Build (MueLu::AmalgamationFactory)
-        [empty list]
-        
-       aggregation: drop tol = 0   [default]
-       aggregation: Dirichlet threshold = 0   [default]
-       aggregation: drop scheme = classical   [default]
-       filtered matrix: use lumping = 1   [default]
-       filtered matrix: reuse graph = 1   [default]
-       filtered matrix: reuse eigenvalue = 1   [default]
-       lightweight wrap = 1   [default]
-       
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 1   [unused]
-      aggregation: max selected neighbors = 0   [unused]
-      aggregation: ordering = natural   [unused]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [unused]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33333
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 256
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2
-   
-   Build (MueLu::RepartitionInterface)
-    Build (MueLu::IsorropiaInterface)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    [empty list]
-    
-   [empty list]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 256
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2
+
+Build (MueLu::RepartitionInterface)
+Build (MueLu::IsorropiaInterface)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+[empty list]
+
+[empty list]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -479,12 +515,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1_epetra.gold
@@ -1,288 +1,314 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -292,12 +318,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother1b_epetra.gold
@@ -1,287 +1,313 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -291,12 +317,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2_epetra.gold
@@ -1,288 +1,314 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -292,12 +318,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother2b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother2b_epetra.gold
@@ -1,287 +1,313 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -291,12 +317,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3_epetra.gold
@@ -1,288 +1,314 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -292,12 +318,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : MueLu::IfpackSmoother{type = point relaxation stand-alone}

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3_tpetra.gold
@@ -1,328 +1,354 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- postsmoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+postsmoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -332,12 +358,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother3b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother3b_epetra.gold
@@ -1,287 +1,313 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -291,12 +317,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : MueLu::IfpackSmoother{type = point relaxation stand-alone}

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_epetra.gold
@@ -1,284 +1,310 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -288,12 +314,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4_tpetra.gold
@@ -1,304 +1,330 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1   [default]
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 1   [unused]
-   aggregation: max selected neighbors = 0   [unused]
-   aggregation: ordering = natural   [unused]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [unused]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -308,12 +334,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLsmoother4b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLsmoother4b_epetra.gold
@@ -1,283 +1,309 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.333
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.333
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -287,12 +313,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_epetra.gold
@@ -1,260 +1,286 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 3
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 Level 4
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -264,12 +290,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1_tpetra.gold
@@ -1,300 +1,326 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 2
-  relaxation: damping factor = 1
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 2
+ relaxation: damping factor = 1
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1   [default]
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 1   [unused]
-  aggregation: max selected neighbors = 0   [unused]
-  aggregation: ordering = natural   [unused]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [unused]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1   [default]
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 1   [unused]
+aggregation: max selected neighbors = 0   [unused]
+aggregation: ordering = natural   [unused]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [unused]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ A = Teuchos::RCP<MueLu::FactoryBase const>{ptr=0,node=0,strong_count=0,weak_count=0}
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -304,12 +330,12 @@ Operator complexity = 1.49
 Smoother complexity = 1.98
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 2, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1b_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/MLunsmoothed1b_epetra.gold
@@ -1,287 +1,313 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 0
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 0
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 0
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 0
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 0
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 2   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 0
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 2   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 0
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 0
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 128) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -291,12 +317,12 @@ Operator complexity = 1.49
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation1_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_epetra.gold
@@ -1,149 +1,165 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.02
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.02
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +169,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation3_tpetra.gold
@@ -1,169 +1,185 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.02
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.02
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +189,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_epetra.gold
@@ -1,157 +1,177 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.05
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = distance laplacian
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory_kokkos)
- write start = -1   [default]
- write end = -1   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.05
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = distance laplacian
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory_kokkos)
- write start = -1   [default]
- write end = -1   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -161,10 +181,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/aggregation4_tpetra.gold
@@ -1,177 +1,197 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.05
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = distance laplacian
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory_kokkos)
- write start = -1   [default]
- write end = -1   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0.05
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = distance laplacian
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- Build (MueLu::CoordinatesTransferFactory_kokkos)
- write start = -1   [default]
- write end = -1   [default]
- 
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.05, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.05
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -181,10 +201,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_epetra.gold
@@ -1,218 +1,238 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<double, int, int, Kokkos::Compat::KokkosDeviceWrapperNode<Kokkos::OpenMP, Kokkos::HostSpace> > >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -222,11 +242,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse1_tpetra.gold
@@ -1,248 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -252,11 +272,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse2_epetra.gold
@@ -1,349 +1,381 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -353,13 +385,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse2_tpetra.gold
@@ -1,399 +1,431 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -403,13 +435,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse3_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/coarse3_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 2.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_e3d_tpetra.gold
@@ -1,157 +1,171 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 3
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 3
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -161,10 +175,10 @@ Operator complexity = 2.11
 Smoother complexity = 2.22
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333  23319     7.00     3.00      1
-  2    1113   9999     8.98     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  23319  7.00     3.00         1  
+  2  1113  9999   8.98     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_np4_tpetra.gold
@@ -1,139 +1,153 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -143,10 +157,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 1, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [2500, 2500], Global nnz: 7498, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [2500, 2500]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [2500, 2500]}}}}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_mhd_tpetra.gold
@@ -1,139 +1,153 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  schwarz: overlap level = 1   [unused]
-  schwarz: combine mode = Zero   [unused]
-  schwarz: use reordering = 0   [unused]
-  subdomain solver name = RILUK   [unused]
-  subdomain solver parameters -> 
-   fact: iluk level-of-fill = 0   [unused]
-   fact: absolute threshold = 0   [unused]
-   fact: relative threshold = 1   [unused]
-   fact: relax value = 0   [unused]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = SCHWARZ})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ schwarz: overlap level = 1   [unused]
+ schwarz: combine mode = Zero   [unused]
+ schwarz: use reordering = 0   [unused]
+ subdomain solver name = RILUK   [unused]
+ subdomain solver parameters -> 
+  fact: iluk level-of-fill = 0   [unused]
+  fact: absolute threshold = 0   [unused]
+  fact: relative threshold = 1   [unused]
+  fact: relax value = 0   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -143,10 +157,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::AdditiveSchwarz": {Initialized: true, Computed: true, Iterations: 1, Overlap level: 0, Subdomain reordering: "none", Combine mode: "ZERO", Global matrix dimensions: [9999, 9999], Inner solver: {"Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}}}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p2d_tpetra.gold
@@ -1,157 +1,171 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -161,10 +175,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_p3d_tpetra.gold
@@ -1,157 +1,171 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -161,10 +175,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_np4_tpetra.gold
@@ -1,173 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +191,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/default_pg_tpetra.gold
@@ -1,173 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Gauss-Seidel
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Gauss-Seidel
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_epetra.gold
@@ -1,335 +1,370 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -339,11 +374,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_epetra.gold
@@ -1,112 +1,124 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -116,11 +128,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_np4_tpetra.gold
@@ -1,115 +1,127 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -119,11 +131,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar1_tpetra.gold
@@ -1,344 +1,379 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1   [unused]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1   [unused]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -348,11 +383,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_epetra.gold
@@ -1,335 +1,373 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20   [unused]
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20   [unused]
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -339,11 +377,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_epetra.gold
@@ -1,112 +1,125 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -116,11 +129,11 @@ Operator complexity = 1.48
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_np4_tpetra.gold
@@ -1,115 +1,128 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -119,11 +132,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/driver_drekar2_tpetra.gold
@@ -1,344 +1,382 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: degree = 2
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: min eigenvalue = 1
-  chebyshev: zero starting solution = 1
-  chebyshev: eigenvalue max iterations = 10
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: degree = 2
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: min eigenvalue = 1
+ chebyshev: zero starting solution = 1
+ chebyshev: eigenvalue max iterations = 10
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 3
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = distance laplacian
-     filtered matrix: use lumping = 1
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 1
-   repartition: min rows per proc = 2000
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.327
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "distance laplacian": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = distance laplacian
+filtered matrix: use lumping = 1
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 1
+repartition: min rows per proc = 2000
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.327
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 1000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -348,11 +386,11 @@ Operator complexity = 1.48
 Smoother complexity = 1.93
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 2, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/emin1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_epetra.gold
@@ -1,165 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -169,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin1_tpetra.gold
@@ -1,185 +1,203 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 2   [default]
- emin: num reuse iterations = 1   [default]
- emin: iterative method = cg   [default]
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 2
+CG iterations
+emin: num iterations = 2   [default]
+emin: num reuse iterations = 1   [default]
+emin: iterative method = cg   [default]
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -189,10 +207,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/emin2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_epetra.gold
@@ -1,165 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -169,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin2_tpetra.gold
@@ -1,185 +1,203 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 4
- emin: num reuse iterations = 1   [default]
- emin: iterative method = sd
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 4
+SD iterations
+emin: num iterations = 4
+emin: num reuse iterations = 1   [default]
+emin: iterative method = sd
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -189,10 +207,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/emin3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_epetra.gold
@@ -1,165 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -169,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/emin3_tpetra.gold
@@ -1,185 +1,203 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator minimization (MueLu::EminPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  Constraint (MueLu::ConstraintFactory)
-   Ppattern (MueLu::PatternFactory)
-   emin: pattern order = 1   [default]
-   
-  [empty list]
-  
- emin: num iterations = 1
- emin: num reuse iterations = 1   [default]
- emin: iterative method = gmres
- P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep P0 = 0   [default]
- Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- Keep Constraint0 = 0   [default]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator minimization (MueLu::EminPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Constraint (MueLu::ConstraintFactory)
+Ppattern (MueLu::PatternFactory)
+emin: pattern order = 1   [default]
+
+[empty list]
+
+Number of emin iterations = 1
+GMRES iterations
+emin: num iterations = 1
+emin: num reuse iterations = 1   [default]
+emin: iterative method = gmres
+P0 = Teuchos::RCP<Xpetra::Matrix<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep P0 = 0   [default]
+Constraint0 = Teuchos::RCP<MueLu::Constraint<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+Keep Constraint0 = 0   [default]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -189,10 +207,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/empty_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/empty_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/onelevel_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/onelevel_epetra.gold
@@ -1,11 +1,12 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -15,8 +16,8 @@ Operator complexity = 1.00
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/onelevel_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/onelevel_tpetra.gold
@@ -1,23 +1,24 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Jacobi   [default]
-  relaxation: sweeps = 1   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Jacobi   [default]
+ relaxation: sweeps = 1   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -27,8 +28,8 @@ Operator complexity = 1.00
 Smoother complexity = 1.33
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_epetra.gold
@@ -1,218 +1,238 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -222,11 +242,11 @@ Operator complexity = 1.34
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np1_tpetra.gold
@@ -1,248 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -252,11 +272,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_epetra.gold
@@ -1,218 +1,238 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -222,11 +242,11 @@ Operator complexity = 1.36
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_1_np4_tpetra.gold
@@ -1,248 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -252,11 +272,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_epetra.gold
@@ -1,215 +1,235 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -219,11 +239,11 @@ Operator complexity = 1.34
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np1_tpetra.gold
@@ -1,245 +1,265 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,11 +269,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_epetra.gold
@@ -1,215 +1,235 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -219,11 +239,11 @@ Operator complexity = 1.36
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_5_np4_tpetra.gold
@@ -1,245 +1,265 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,11 +269,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_epetra.gold
@@ -1,215 +1,234 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -219,11 +238,11 @@ Operator complexity = 1.34
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np1_tpetra.gold
@@ -1,245 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,11 +268,11 @@ Operator complexity = 1.34
 Smoother complexity = 1.57
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
-  2      192   1674     8.72     8.85      1
-  3       24    190     7.92     8.00      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
+  2  192    1674   8.72     8.85         1  
+  3  24     190    7.92     8.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_epetra.gold
@@ -1,215 +1,234 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -219,11 +238,11 @@ Operator complexity = 1.36
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_6_np4_tpetra.gold
@@ -1,245 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -249,11 +268,11 @@ Operator complexity = 1.36
 Smoother complexity = 1.59
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
-  2      216   2150     9.95     7.87      4
-  3       32    434    13.56     6.75      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
+  2  216    2150   9.95     7.87         4  
+  3  32     434    13.56    6.75         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_epetra.gold
@@ -1,76 +1,83 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -80,9 +87,9 @@ Operator complexity = 1.30
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np1_tpetra.gold
@@ -1,86 +1,93 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -90,9 +97,9 @@ Operator complexity = 1.30
 Smoother complexity = 1.20
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               1
-  1     1700  14928     8.78     5.88      1
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  1  
+  1  1700   14928  8.78     5.88         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_epetra.gold
@@ -1,76 +1,83 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -80,9 +87,9 @@ Operator complexity = 1.31
 Smoother complexity = 0.00
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/operator_solve_7_np4_tpetra.gold
@@ -1,86 +1,93 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -90,9 +97,9 @@ Operator complexity = 1.31
 Smoother complexity = 1.20
 Cycle type          = V
 
-level   rows    nnz  nnz/row  c ratio  procs
-  0    10000  49600     4.96               4
-  1     1700  15318     9.01     5.88      4
+level  rows   nnz    nnz/row  c ratio  procs
+  0  10000  49600  4.96                  4  
+  1  1700   15318  9.01     5.88         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [10000, 10000], Global nnz: 49600}
 

--- a/packages/muelu/test/interface/kokkos/Output/pg1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_epetra.gold
@@ -1,153 +1,167 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -157,10 +171,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg1_tpetra.gold
@@ -1,173 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/pg2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_epetra.gold
@@ -1,153 +1,167 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -157,10 +171,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/pg2_tpetra.gold
@@ -1,173 +1,187 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-    Build (MueLu::CoalesceDropFactory_kokkos)
-     Build (MueLu::AmalgamationFactory)
-     [empty list]
-     
-    aggregation: drop tol = 0   [default]
-    aggregation: Dirichlet threshold = 0   [default]
-    aggregation: drop scheme = classical   [default]
-    filtered matrix: use lumping = 1   [default]
-    filtered matrix: reuse graph = 1   [default]
-    filtered matrix: reuse eigenvalue = 1   [default]
-    lightweight wrap = 1
-    
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
-  PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
- Minimization norm = 2   [default]
- ReUseRowBasedOmegas = 0   [default]
- 
- Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
-  Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
-   PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
-  Minimization norm = 2   [default]
-  ReUseRowBasedOmegas = 0   [default]
-  
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+Call prolongator factory for calculating restrictor (MueLu::GenericRFactory)
+Prolongator smoothing (PG-AMG) (MueLu::PgPFactory)
+PgPFactory::ComputeRowBasedOmega (MueLu::PgPFactory)
+Minimization norm = 2   [default]
+ReUseRowBasedOmegas = 0   [default]
+
+[empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -177,10 +191,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_epetra.gold
@@ -1,223 +1,246 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +250,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_epetra.gold
@@ -1,216 +1,238 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -220,10 +242,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_np4_tpetra.gold
@@ -1,236 +1,258 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +262,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition1_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_epetra.gold
@@ -1,223 +1,246 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +250,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_epetra.gold
@@ -1,223 +1,246 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +250,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_np4_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition3_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 0
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 0
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_epetra.gold
@@ -1,223 +1,245 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +249,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_epetra.gold
@@ -1,223 +1,245 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  Reindex = 1
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ Reindex = 1
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +249,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_np4_tpetra.gold
@@ -1,243 +1,265 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +269,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      4
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         4  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/repartition4_tpetra.gold
@@ -1,243 +1,265 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0   [unused]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0   [unused]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 0   [unused]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 0
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 0   [unused]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 0
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +269,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_epetra.gold
@@ -1,223 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -239,16 +260,17 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
 Level 2
 
@@ -260,10 +282,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_epetra.gold
@@ -1,216 +1,236 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -220,10 +240,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -232,16 +252,17 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
 Level 2
 
@@ -253,10 +274,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_np4_tpetra.gold
@@ -1,236 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,26 +272,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -283,10 +304,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-1_tpetra.gold
@@ -1,243 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,26 +280,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -290,10 +312,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_epetra.gold
@@ -1,199 +1,220 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -203,10 +224,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -215,16 +236,17 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
 Level 2
 
@@ -236,10 +258,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_epetra.gold
@@ -1,192 +1,212 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -196,10 +216,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -208,16 +228,17 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
 Level 2
 
@@ -229,10 +250,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_np4_tpetra.gold
@@ -1,212 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -216,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -228,26 +248,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -259,10 +280,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RAP-2_tpetra.gold
@@ -1,219 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,10 +244,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -235,26 +256,27 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
 Level 2
 
@@ -266,10 +288,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_epetra.gold
@@ -1,199 +1,220 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -203,10 +224,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -215,86 +236,96 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -304,10 +335,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_epetra.gold
@@ -1,192 +1,212 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -196,10 +216,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -208,79 +228,89 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -290,10 +320,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_np4_tpetra.gold
@@ -1,212 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -216,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -228,99 +248,109 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -330,10 +360,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-RP-2_tpetra.gold
@@ -1,219 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,10 +244,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -235,106 +256,116 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 1
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -344,10 +375,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_epetra.gold
@@ -1,223 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -239,226 +260,246 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -468,10 +509,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_epetra.gold
@@ -1,216 +1,236 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -220,10 +240,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -232,219 +252,239 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -454,10 +494,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_np4_tpetra.gold
@@ -1,236 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,239 +272,259 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -494,10 +534,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-S-1_tpetra.gold
@@ -1,243 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,246 +280,266 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -508,10 +549,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_epetra.gold
@@ -1,223 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -239,6 +260,7 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -251,10 +273,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_epetra.gold
@@ -1,216 +1,236 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -220,10 +240,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -232,6 +252,7 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -244,10 +265,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_np4_tpetra.gold
@@ -1,236 +1,256 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +260,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,6 +272,7 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -264,10 +285,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-full-1_tpetra.gold
@@ -1,243 +1,264 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 1
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+repartition: rebalance P and R = 1
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +268,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,6 +280,7 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
 Level 1
 Level 2
@@ -271,10 +293,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_epetra.gold
@@ -1,223 +1,246 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +250,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -239,226 +262,248 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -468,10 +513,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_epetra.gold
@@ -1,216 +1,238 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -220,10 +242,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -232,219 +254,241 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -454,10 +498,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_np4_tpetra.gold
@@ -1,236 +1,258 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +262,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,239 +274,261 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -494,10 +538,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-none_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,246 +282,268 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -508,10 +553,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_epetra.gold
@@ -1,223 +1,246 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +250,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -239,148 +262,162 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -390,10 +427,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_epetra.gold
@@ -1,216 +1,238 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -220,10 +242,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -232,141 +254,155 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -376,10 +412,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_np4_tpetra.gold
@@ -1,236 +1,258 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +262,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,161 +274,175 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -416,10 +452,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-1_tpetra.gold
@@ -1,243 +1,266 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +270,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,168 +282,182 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (<Direct> solver interface)
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (<Direct> solver interface)
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -430,10 +467,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_epetra.gold
@@ -1,223 +1,248 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -227,10 +252,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -239,185 +264,205 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -427,10 +472,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_epetra.gold
@@ -1,216 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -220,10 +244,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -232,178 +256,198 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -413,10 +457,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_np4_tpetra.gold
@@ -1,236 +1,260 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -240,10 +264,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -252,198 +276,218 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10015})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -453,10 +497,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-2_tpetra.gold
@@ -1,243 +1,268 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -247,10 +272,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -259,205 +284,225 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Prolongator smoothing (MueLu::SaPFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0.02
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  sa: damping factor = 1.33   [default]
-  sa: calculate eigenvalue estimate = 0   [default]
-  sa: eigenvalue estimate num iterations = 10   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0.02
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0.02, blocksize = 1
+Lumping dropped entries
+aggregation: drop tol = 0.02
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -467,10 +512,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_epetra.gold
@@ -1,209 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -213,10 +236,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -225,161 +248,178 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -389,10 +429,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_epetra.gold
@@ -1,202 +1,224 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -206,10 +228,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 
@@ -218,154 +240,171 @@ Smoother (level 1) both : MueLu::IfpackSmoother{type = point relaxation stand-al
 Smoother (level 2) pre  : MueLu::AmesosSmoother{type = <ignored>}
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -375,10 +414,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_np4_tpetra.gold
@@ -1,222 +1,244 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -226,10 +248,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -238,174 +260,191 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3335, 3335], Global nnz: 10003})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -415,10 +454,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10003     3.00     3.00      4
-  2    1112   3334     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10003  3.00     3.00         4  
+  2  1112  3334   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/reuse-tP-3_tpetra.gold
@@ -1,229 +1,252 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -233,10 +256,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 
@@ -245,181 +268,198 @@ Smoother (level 1) both : "Ifpack2::Relaxation": {Initialized: true, Computed: t
 Smoother (level 2) pre  : <Direct> solver interface
 Smoother (level 2) post : no smoother
 
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
-  Transpose P (MueLu::TransPFactory)
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
-  Computing Ac (MueLu::RAPFactory)
-   Reusing previous AP data
-   Reusing previous RAP data
-  Build (MueLu::CoordinatesTransferFactory_kokkos)
-  write start = -1   [default]
-  write end = -1   [default]
-  
-  transpose: use implicit = 0   [default]
-  rap: triple product = 0   [default]
-  rap: fix zero diagonals = 0   [default]
-  CheckMainDiagonal = 0   [default]
-  RepairMainDiagonal = 0   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
- keep smoother data = 1
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Computing Ac (MueLu::RAPFactory)
+Reusing previous AP data
+Reusing previous RAP data
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+Reusing coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother ("Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [3333, 3333], Global nnz: 9997})
+keep smoother data = 1
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Build (MueLu::TentativePFactory_kokkos)
-     Build (MueLu::UncoupledAggregationFactory_kokkos)
-      Build (MueLu::CoalesceDropFactory_kokkos)
-       Build (MueLu::AmalgamationFactory)
-       [empty list]
-       
-      aggregation: drop tol = 0   [default]
-      aggregation: Dirichlet threshold = 0   [default]
-      aggregation: drop scheme = classical   [default]
-      filtered matrix: use lumping = 1   [default]
-      filtered matrix: reuse graph = 1   [default]
-      filtered matrix: reuse eigenvalue = 1   [default]
-      lightweight wrap = 1
-      
-     aggregation: max agg size = -1   [default]
-     aggregation: min agg size = 2   [default]
-     aggregation: max selected neighbors = 0   [default]
-     aggregation: ordering = natural   [default]
-     aggregation: enable phase 1 = 1   [default]
-     aggregation: phase 1 algorithm = Serial   [default]
-     aggregation: enable phase 2a = 1   [default]
-     aggregation: enable phase 2b = 1   [default]
-     aggregation: enable phase 3 = 1   [default]
-     aggregation: preserve Dirichlet points = 0   [default]
-     aggregation: allow user-specified singletons = 0   [default]
-     OnePt aggregate map name =    [default]
-     OnePt aggregate map factory =    [default]
-     
-     Nullspace factory (MueLu::NullspaceFactory_kokkos)
-     Fine level nullspace = Nullspace
-     
-     Build (MueLu::CoarseMapFactory_kokkos)
-     [empty list]
-     
-    tentative: calculate qr = 1   [default]
-    tentative: build coarse coordinates = 1   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-    Transpose P (MueLu::TransPFactory)
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 0   [default]
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Build (MueLu::RebalanceTransferFactory)
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Restriction
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Build (MueLu::RebalanceTransferFactory)
+Using original restrictor
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Restriction
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -429,10 +469,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_epetra.gold
@@ -1,145 +1,159 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -149,10 +163,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother10_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_epetra.gold
@@ -1,159 +1,173 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +177,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : MueLu::IfpackSmoother{type = point relaxation stand-alone}

--- a/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother11_tpetra.gold
@@ -1,207 +1,221 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 3
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: sweeps = 0
-  relaxation: type = Jacobi   [default]
-  relaxation: damping factor = 1   [default]
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 3
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: sweeps = 0
+ relaxation: type = Jacobi   [default]
+ relaxation: damping factor = 1   [default]
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -211,10 +225,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 3, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Jacobi, sweeps: 0, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_epetra.gold
@@ -1,346 +1,378 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 5   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 5   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 4   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 4   [unused]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2.99461   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2.99461   [unused]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2.99194   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2.99194   [unused]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -350,13 +382,13 @@ Operator complexity = 1.50
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother12_tpetra.gold
@@ -1,376 +1,408 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 5
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 5
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 4
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 4
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 3
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2.99461
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2.99461
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 4
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 2.99194
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 2.99194
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 5
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 100) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -380,13 +412,13 @@ Operator complexity = 1.50
 Smoother complexity = 1.99
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
-  3     371   1111     2.99     2.99      1
-  4     124    370     2.98     2.99      1
-  5      42    124     2.95     2.95      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
+  3  371   1111   2.99     2.99         1  
+  4  124   370    2.98     2.99         1  
+  5  42    124    2.95     2.95         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 2, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_epetra.gold
@@ -1,159 +1,173 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILU})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILU})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILU})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILU})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +177,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = Chebyshev}
 Smoother (level 0) post : MueLu::IfpackSmoother{type = ILU}

--- a/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother13_tpetra.gold
@@ -1,171 +1,185 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RILUK})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -175,10 +189,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::RILUK": {Initialized: true, Computed: true, Level-of-fill: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}, "Ifpack2::LocalSparseTriangularSolver": {Initialized: true, Computed: true, Matrix: not null, Global matrix dimensions: [9999, 9999]}}

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother1_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother2_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : MueLu::IfpackSmoother{type = point relaxation stand-alone}

--- a/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother3_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_epetra.gold
@@ -1,131 +1,145 @@
+Clearing old data (if any)
 Level 0
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -135,10 +149,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother4_tpetra.gold
@@ -1,131 +1,145 @@
+Clearing old data (if any)
 Level 0
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -135,10 +149,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : no smoother
 Smoother (level 0) post : no smoother

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_epetra.gold
@@ -1,145 +1,159 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -149,10 +163,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = Chebyshev}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother5_tpetra.gold
@@ -1,157 +1,171 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -161,10 +175,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_epetra.gold
@@ -1,145 +1,159 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -149,10 +163,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = ILUT}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother6_tpetra.gold
@@ -1,145 +1,159 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -149,10 +163,10 @@ Operator complexity = 1.44
 Smoother complexity = 2.67
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_epetra.gold
@@ -1,159 +1,173 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20   [unused]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = Chebyshev})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20   [unused]
+
+Setup Smoother (MueLu::IfpackSmoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -163,10 +177,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : MueLu::IfpackSmoother{type = Chebyshev}
 Smoother (level 0) post : MueLu::IfpackSmoother{type = ILUT}

--- a/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/smoother9_tpetra.gold
@@ -1,171 +1,185 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  chebyshev: ratio eigenvalue = 20
-  chebyshev: boost factor = 1.1   [unused]
-  chebyshev: min diagonal value = 2.22045e-16   [default]
-  chebyshev: degree = 1   [default]
-  chebyshev: eigenvalue max iterations = 10   [default]
-  chebyshev: zero starting solution = 1   [default]
-  chebyshev: assume matrix does not change = 0   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = CHEBYSHEV})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ chebyshev: ratio eigenvalue = 20
+ chebyshev: boost factor = 1.1   [unused]
+ chebyshev: min diagonal value = 2.22045e-16   [default]
+ chebyshev: degree = 1   [default]
+ chebyshev: eigenvalue max iterations = 10   [default]
+ chebyshev: zero starting solution = 1   [default]
+ chebyshev: assume matrix does not change = 0   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = ILUT})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ [empty list]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -175,10 +189,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) pre  : "Ifpack2::Chebyshev": {Initialized: true, Computed: true, "Ifpack2::Details::Chebyshev":{degree: 1, lambdaMax = <ignored>, alpha: 20, lambdaMin = <ignored>, boost factor: 1.1}, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 Smoother (level 0) post : "Ifpack2::ILUT": {Initialized: true, Computed: true, Level-of-fill: 1, absolute threshold: 0, relative threshold: 1, relaxation value: 0, Global matrix dimensions: [9999, 9999], Global nnz: 29995}

--- a/packages/muelu/test/interface/kokkos/Output/sync1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_epetra.gold
@@ -1,149 +1,163 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -153,10 +167,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/sync1_tpetra.gold
@@ -1,169 +1,183 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -173,10 +187,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_epetra.gold
@@ -1,141 +1,155 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -145,10 +159,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose1_tpetra.gold
@@ -1,161 +1,175 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Prolongator smoothing (MueLu::SaPFactory_kokkos)
-  Build (MueLu::CoalesceDropFactory_kokkos)
-   Build (MueLu::AmalgamationFactory)
-   [empty list]
-   
-  aggregation: drop tol = 0   [default]
-  aggregation: Dirichlet threshold = 0   [default]
-  aggregation: drop scheme = classical   [default]
-  filtered matrix: use lumping = 1   [default]
-  filtered matrix: reuse graph = 1   [default]
-  filtered matrix: reuse eigenvalue = 1   [default]
-  lightweight wrap = 1
-  
-  Build (MueLu::TentativePFactory_kokkos)
-   Build (MueLu::UncoupledAggregationFactory_kokkos)
-   aggregation: max agg size = -1   [default]
-   aggregation: min agg size = 2   [default]
-   aggregation: max selected neighbors = 0   [default]
-   aggregation: ordering = natural   [default]
-   aggregation: enable phase 1 = 1   [default]
-   aggregation: phase 1 algorithm = Serial   [default]
-   aggregation: enable phase 2a = 1   [default]
-   aggregation: enable phase 2b = 1   [default]
-   aggregation: enable phase 3 = 1   [default]
-   aggregation: preserve Dirichlet points = 0   [default]
-   aggregation: allow user-specified singletons = 0   [default]
-   OnePt aggregate map name =    [default]
-   OnePt aggregate map factory =    [default]
-   
-   Nullspace factory (MueLu::NullspaceFactory_kokkos)
-   Fine level nullspace = Nullspace
-   
-   Build (MueLu::CoarseMapFactory_kokkos)
-   [empty list]
-   
-  tentative: calculate qr = 1   [default]
-  tentative: build coarse coordinates = 1   [default]
-  matrixmatrix: kernel params -> 
-   [empty list]
-  
- sa: damping factor = 1.33   [default]
- sa: calculate eigenvalue estimate = 0   [default]
- sa: eigenvalue estimate num iterations = 10   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 1
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -165,10 +179,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_epetra.gold
@@ -1,199 +1,220 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -203,10 +224,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_epetra.gold
@@ -1,192 +1,212 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -196,10 +216,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_np4_tpetra.gold
@@ -1,212 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -216,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose2_tpetra.gold
@@ -1,219 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0   [default]
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0   [default]
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,10 +244,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_epetra.gold
@@ -1,199 +1,220 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -203,10 +224,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_epetra.gold
@@ -1,192 +1,212 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -196,10 +216,10 @@ Operator complexity = 1.45
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_np4_tpetra.gold
@@ -1,212 +1,232 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -216,10 +236,10 @@ Operator complexity = 1.45
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               4
-  1    3335  10015     3.00     3.00      4
-  2    1112   3340     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  4  
+  1  3335  10015  3.00     3.00         4  
+  2  1112  3340   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/transpose3_tpetra.gold
@@ -1,219 +1,240 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+repartition: use subcommunicators = 1   [default]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::RebalanceTransferFactory)
-  Build (MueLu::RepartitionFactory)
-   Computing Ac (MueLu::RAPFactory)
-    Prolongator smoothing (MueLu::SaPFactory_kokkos)
-     Build (MueLu::CoalesceDropFactory_kokkos)
-      Build (MueLu::AmalgamationFactory)
-      [empty list]
-      
-     aggregation: drop tol = 0   [default]
-     aggregation: Dirichlet threshold = 0   [default]
-     aggregation: drop scheme = classical   [default]
-     filtered matrix: use lumping = 1   [default]
-     filtered matrix: reuse graph = 1   [default]
-     filtered matrix: reuse eigenvalue = 1   [default]
-     lightweight wrap = 1
-     
-     Build (MueLu::TentativePFactory_kokkos)
-      Build (MueLu::UncoupledAggregationFactory_kokkos)
-      aggregation: max agg size = -1   [default]
-      aggregation: min agg size = 2   [default]
-      aggregation: max selected neighbors = 0   [default]
-      aggregation: ordering = natural   [default]
-      aggregation: enable phase 1 = 1   [default]
-      aggregation: phase 1 algorithm = Serial   [default]
-      aggregation: enable phase 2a = 1   [default]
-      aggregation: enable phase 2b = 1   [default]
-      aggregation: enable phase 3 = 1   [default]
-      aggregation: preserve Dirichlet points = 0   [default]
-      aggregation: allow user-specified singletons = 0   [default]
-      OnePt aggregate map name =    [default]
-      OnePt aggregate map factory =    [default]
-      
-      Nullspace factory (MueLu::NullspaceFactory_kokkos)
-      Fine level nullspace = Nullspace
-      
-      Build (MueLu::CoarseMapFactory_kokkos)
-      [empty list]
-      
-     tentative: calculate qr = 1   [default]
-     tentative: build coarse coordinates = 1   [default]
-     matrixmatrix: kernel params -> 
-      [empty list]
-     
-    sa: damping factor = 1.33   [default]
-    sa: calculate eigenvalue estimate = 0   [default]
-    sa: eigenvalue estimate num iterations = 10   [default]
-    matrixmatrix: kernel params -> 
-     [empty list]
-    
-   Build (MueLu::CoordinatesTransferFactory_kokkos)
-   write start = -1   [default]
-   write end = -1   [default]
-   
-   transpose: use implicit = 1
-   rap: triple product = 0   [default]
-   rap: fix zero diagonals = 0   [default]
-   CheckMainDiagonal = 0   [default]
-   RepairMainDiagonal = 0   [default]
-   matrixmatrix: kernel params -> 
-    [empty list]
-   
-   Build (MueLu::RepartitionHeuristicFactory)
-   repartition: start level = 2   [default]
-   repartition: min rows per proc = 800   [default]
-   repartition: target rows per proc = 0   [default]
-   repartition: max imbalance = 1.2   [default]
-   
-   Build (MueLu::Zoltan2Interface)
-   ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
-   
-  repartition: print partition distribution = 0   [default]
-  repartition: remap parts = 1   [default]
-  repartition: remap num values = 4   [default]
-  
- repartition: rebalance P and R = 0
- transpose: use implicit = 0   [default]
- repartition: use subcommunicators = 1   [default]
- type = Interpolation
- write start = -1   [default]
- write end = -1   [default]
- 
- Computing Ac (MueLu::RebalanceAcFactory)
- repartition: use subcommunicators = 1   [default]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::RebalanceTransferFactory)
+Build (MueLu::RepartitionFactory)
+Computing Ac (MueLu::RAPFactory)
+Prolongator smoothing (MueLu::SaPFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+sa: damping factor = 1.33   [default]
+sa: calculate eigenvalue estimate = 0   [default]
+sa: eigenvalue estimate num iterations = 10   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+RAPFactory: call transfer factory: MueLu::CoordinatesTransferFactory_kokkos
+Build (MueLu::CoordinatesTransferFactory_kokkos)
+Transferring coordinates
+write start = -1   [default]
+write end = -1   [default]
+
+transpose: use implicit = 1
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Build (MueLu::RepartitionHeuristicFactory)
+repartition: start level = 2   [default]
+repartition: min rows per proc = 800   [default]
+repartition: target rows per proc = 0   [default]
+repartition: max imbalance = 1.2   [default]
+
+Build (MueLu::Zoltan2Interface)
+ParameterList = Teuchos::RCP<Teuchos::ParameterList const>{<ignored>}   [unused]
+
+repartition: print partition distribution = 0   [default]
+repartition: remap parts = 1   [default]
+repartition: remap num values = 4   [default]
+
+Using original prolongator
+repartition: rebalance P and R = 0
+transpose: use implicit = 0   [default]
+repartition: use subcommunicators = 1   [default]
+type = Interpolation
+write start = -1   [default]
+write end = -1   [default]
+
+Computing Ac (MueLu::RebalanceAcFactory)
+Replacing maps with a subcommunicator
+repartition: use subcommunicators = 1   [default]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -223,10 +244,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_epetra.gold
@@ -1,135 +1,149 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -139,10 +153,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed1_tpetra.gold
@@ -1,155 +1,169 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 1   [default]
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 1   [default]
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -159,10 +173,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_epetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_epetra.gold
@@ -1,135 +1,149 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 0
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = symmetric Gauss-Seidel   [unused]
-  relaxation: sweeps = 1   [unused]
-  relaxation: damping factor = 1   [unused]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 0
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::IfpackSmoother{type = point relaxation stand-alone})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = symmetric Gauss-Seidel   [unused]
+ relaxation: sweeps = 1   [unused]
+ relaxation: damping factor = 1   [unused]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 0
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 0
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::AmesosSmoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -139,10 +153,10 @@ Operator complexity = 1.44
 Smoother complexity = 0.00
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : MueLu::IfpackSmoother{type = point relaxation stand-alone}
 

--- a/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
+++ b/packages/muelu/test/interface/kokkos/Output/unsmoothed2_tpetra.gold
@@ -1,155 +1,169 @@
+Clearing old data (if any)
 Level 0
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 1
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 0
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- smoother -> 
-  relaxation: type = Symmetric Gauss-Seidel
-  relaxation: sweeps = 1
-  relaxation: damping factor = 1
-  relaxation: zero starting solution = 1   [default]
-  relaxation: backward mode = 0   [default]
-  relaxation: use l1 = 0   [default]
-  relaxation: l1 eta = 1.5   [default]
-  relaxation: min diagonal value = 0   [default]
-  relaxation: fix tiny diagonal entries = 0   [default]
-  relaxation: check diagonal entries = 0   [default]
-  relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
-  relaxation: symmetric matrix structure = 0   [default]
-  relaxation: ifpack2 dump matrix = 0   [default]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 0
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Setup Smoother (MueLu::Ifpack2Smoother{type = RELAXATION})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+smoother -> 
+ relaxation: type = Symmetric Gauss-Seidel
+ relaxation: sweeps = 1
+ relaxation: damping factor = 1
+ relaxation: zero starting solution = 1   [default]
+ relaxation: backward mode = 0   [default]
+ relaxation: use l1 = 0   [default]
+ relaxation: l1 eta = 1.5   [default]
+ relaxation: min diagonal value = 0   [default]
+ relaxation: fix tiny diagonal entries = 0   [default]
+ relaxation: check diagonal entries = 0   [default]
+ relaxation: local smoothing indices = Teuchos::ArrayRCP<int>{ptr=0,lowerOffset=0,upperOffset=-1,size=0,node=0,strong_count=0,weak_count=0}   [default]
+ relaxation: symmetric matrix structure = 0   [default]
+ relaxation: ifpack2 dump matrix = 0   [default]
+
 Level 2
- Build (MueLu::TentativePFactory_kokkos)
-  Build (MueLu::UncoupledAggregationFactory_kokkos)
-   Build (MueLu::CoalesceDropFactory_kokkos)
-    Build (MueLu::AmalgamationFactory)
-    [empty list]
-    
-   aggregation: drop tol = 0   [default]
-   aggregation: Dirichlet threshold = 0   [default]
-   aggregation: drop scheme = classical   [default]
-   filtered matrix: use lumping = 1   [default]
-   filtered matrix: reuse graph = 1   [default]
-   filtered matrix: reuse eigenvalue = 1   [default]
-   lightweight wrap = 1
-   
-  aggregation: max agg size = -1   [default]
-  aggregation: min agg size = 2   [default]
-  aggregation: max selected neighbors = 0   [default]
-  aggregation: ordering = natural   [default]
-  aggregation: enable phase 1 = 1   [default]
-  aggregation: phase 1 algorithm = Serial   [default]
-  aggregation: enable phase 2a = 1   [default]
-  aggregation: enable phase 2b = 1   [default]
-  aggregation: enable phase 3 = 1   [default]
-  aggregation: preserve Dirichlet points = 0   [default]
-  aggregation: allow user-specified singletons = 0   [default]
-  OnePt aggregate map name =    [default]
-  OnePt aggregate map factory =    [default]
-  
-  Nullspace factory (MueLu::NullspaceFactory_kokkos)
-  Fine level nullspace = Nullspace
-  
-  Build (MueLu::CoarseMapFactory_kokkos)
-  [empty list]
-  
- tentative: calculate qr = 0
- tentative: build coarse coordinates = 1   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Transpose P (MueLu::TransPFactory)
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Computing Ac (MueLu::RAPFactory)
- transpose: use implicit = 0   [default]
- rap: triple product = 0   [default]
- rap: fix zero diagonals = 0   [default]
- CheckMainDiagonal = 0   [default]
- RepairMainDiagonal = 0   [default]
- matrixmatrix: kernel params -> 
-  [empty list]
- 
- Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
- keep smoother data = 0   [default]
- PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
- presmoother -> 
-  [empty list]
- 
+Build (MueLu::TentativePFactory_kokkos)
+Build (MueLu::UncoupledAggregationFactory_kokkos)
+Build (MueLu::CoalesceDropFactory_kokkos)
+Build (MueLu::AmalgamationFactory)
+[empty list]
+
+algorithm = "classical": threshold = 0, blocksize = 1
+aggregation: drop tol = 0   [default]
+aggregation: Dirichlet threshold = 0   [default]
+aggregation: drop scheme = classical   [default]
+filtered matrix: use lumping = 1   [default]
+filtered matrix: reuse graph = 1   [default]
+filtered matrix: reuse eigenvalue = 1   [default]
+lightweight wrap = 1
+
+BuildAggregates (Phase - (Dirichlet))
+BuildAggregates (Phase 1 (main))
+BuildAggregates (Phase 2a (secondary))
+BuildAggregates (Phase 2b (expansion))
+BuildAggregates (Phase 3 (cleanup))
+aggregation: max agg size = -1   [default]
+aggregation: min agg size = 2   [default]
+aggregation: max selected neighbors = 0   [default]
+aggregation: ordering = natural   [default]
+aggregation: enable phase 1 = 1   [default]
+aggregation: phase 1 algorithm = Serial   [default]
+aggregation: enable phase 2a = 1   [default]
+aggregation: enable phase 2b = 1   [default]
+aggregation: enable phase 3 = 1   [default]
+aggregation: preserve Dirichlet points = 0   [default]
+aggregation: allow user-specified singletons = 0   [default]
+OnePt aggregate map name =    [default]
+OnePt aggregate map factory =    [default]
+
+Nullspace factory (MueLu::NullspaceFactory_kokkos)
+Fine level nullspace = Nullspace
+
+Build (MueLu::CoarseMapFactory_kokkos)
+[empty list]
+
+tentative: calculate qr = 0
+tentative: build coarse coordinates = 1   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Transpose P (MueLu::TransPFactory)
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Computing Ac (MueLu::RAPFactory)
+transpose: use implicit = 0   [default]
+rap: triple product = 0   [default]
+rap: fix zero diagonals = 0   [default]
+CheckMainDiagonal = 0   [default]
+RepairMainDiagonal = 0   [default]
+matrixmatrix: kernel params -> 
+ [empty list]
+
+Max coarse size (<= 2000) achieved
+Setup Smoother (MueLu::Amesos2Smoother{type = <ignored>})
+keep smoother data = 0   [default]
+PreSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+PostSmoother data = Teuchos::RCP<MueLu::SmootherPrototype<ignored> >{ptr=0,node=0,strong_count=0,weak_count=0}   [default]
+presmoother -> 
+ [empty list]
+
 
 --------------------------------------------------------------------------------
 ---                            Multigrid Summary                             ---
@@ -159,10 +173,10 @@ Operator complexity = 1.44
 Smoother complexity = 1.78
 Cycle type          = V
 
-level  rows    nnz  nnz/row  c ratio  procs
-  0    9999  29995     3.00               1
-  1    3333   9997     3.00     3.00      1
-  2    1111   3331     3.00     3.00      1
+level  rows  nnz    nnz/row  c ratio  procs
+  0  9999  29995  3.00                  1  
+  1  3333  9997   3.00     3.00         1  
+  2  1111  3331   3.00     3.00         1  
 
 Smoother (level 0) both : "Ifpack2::Relaxation": {Initialized: true, Computed: true, Type: Symmetric Gauss-Seidel, sweeps: 1, damping factor: 1, Global matrix dimensions: [9999, 9999], Global nnz: 29995}
 

--- a/packages/muelu/test/unit_tests/MueLu_TestHelpers_Common.hpp
+++ b/packages/muelu/test/unit_tests/MueLu_TestHelpers_Common.hpp
@@ -109,7 +109,7 @@
 // Macro to set MueLu's internal oh-so FancyOStream to be the same as the one used by Teuchos' unit testing framework.
 // This prevents MueLu's output from intermingling with with the unit test pass/fail summary lines.
 #define MUELU_TESTING_SET_OSTREAM \
-   MueLu::VerboseObject::SetDefaultOStream(Teuchos::fancyOStream(out.getOStream()));
+   MueLu::VerboseObject::SetMueLuOStream(Teuchos::fancyOStream(out.getOStream()));
 
 #define MUELU_TESTING_DO_NOT_TEST(lib,packagesNotEnabled) \
   if (TestHelpers::Parameters::getLib() == lib) { \


### PR DESCRIPTION
@trilinos/muelu 

## Description
MueLu is handling which messages get printed on which rank itself, in `MueLu_VerboseObject`. There, we set the default output stream of the underlying Teuchos object to a staticly defined stream, and set it to output on all ranks. However, in `MueLu_HierarchyManager` we take that stream and set it to output on rank 0 only. Teuchos states that the behavior of calling `setOutputToRootOnly` more than once is undefined. What happens is that all but rank 0 irreversibly replace their streams with blackhole streams. This means that all MueLu objects everywhere except on rank 0 do not print anymore. This can also happen when `setOutputToRootOnly` is called from somewhere else on the Teuchos default stream.

With the changes in this PR, we do not set the output stream used by MueLu to be the default Teuchos output stream in order to that somewhere else `setOutputToRootOnly` is called on it.

The change was tested by running
```
mpirun -np 2 ./MueLu_Driver.exe --matrixType=Laplace3D --xml=scaling.xml --nx=34 --ny=34 --nz=34 --rebuild=1 --solver=none --notimings
```

## Related Issues

* Addresses  #1471 and #1489